### PR TITLE
Fix/9 various bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changelog
 
+### v1.0.4 - Bug Fixes (2026-03-09)
+
+- Implemented TOML 1.0 Unicode escape parsing for basic strings (`\uXXXX` and `\UXXXXXXXX`).
+- Added missing basic-string escape support for backspace (`\b`) and form feed (`\f`).
+- Fixed multiline string handling to trim the first newline in multiline literal strings and to honor line-ending backslash whitespace trimming in multiline basic strings.
+- Fixed local time tokenization and parsing for bare TOML time values such as `07:32:00`.
+- Tightened numeric validation to reject invalid underscore placement, decimal leading zeros, and hexadecimal floating-point syntax.
+- Fixed serializer output for quoted dotted keys so table headers and arrays of tables preserve literal dotted keys instead of splitting them into paths.
+- Added regression coverage for Unicode escapes, multiline string trimming, local-time parsing, numeric validation, inline quoted dotted keys, and quoted array-of-table serialization.
+
 ### v1.0.3 - Bug Fixes (2026-02-15)
 
 - Fixed parser navigation for dotted table paths when an intermediate key is an array of tables (e.g., `[fruits.physical]` after `[[fruits]]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing basic-string escape support for backspace (`\b`) and form feed (`\f`).
 - Fixed multiline string handling to trim the first newline in multiline literal strings and to honor line-ending backslash whitespace trimming in multiline basic strings.
 - Fixed local time tokenization and parsing for bare TOML time values such as `07:32:00`.
+- Fixed parsing of local datetimes that use a space separator (for example `1979-05-27 07:32:00`) so the time component is preserved.
 - Tightened numeric validation to reject invalid underscore placement, decimal leading zeros, and hexadecimal floating-point syntax.
+- Fixed basic-string escape validation to reject invalid TOML escapes such as `\'`.
 - Fixed serializer output for quoted dotted keys so table headers and arrays of tables preserve literal dotted keys instead of splitting them into paths.
-- Added regression coverage for Unicode escapes, multiline string trimming, local-time parsing, numeric validation, inline quoted dotted keys, and quoted array-of-table serialization.
+- Added regression coverage for Unicode escapes, multiline string trimming, local-time parsing, space-separated local datetimes, numeric validation, invalid basic-string escapes, inline quoted dotted keys, and quoted array-of-table serialization.
 
 ### v1.0.3 - Bug Fixes (2026-02-15)
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![TOML](https://img.shields.io/badge/TOML-1.0.0-green.svg)](https://toml.io/)
 [![Version](https://img.shields.io/badge/Version-1.0.4-blueviolet.svg)]()
 
-A robust [TOML (Tom's Obvious, Minimal Language)](https://toml.io/) parser and serializer for Free Pascal with broad TOML v1.0.0 support, including nested tables, arrays of tables, quoted dotted keys, Unicode escapes, and local date/time values.
+A robust [TOML (Tom's Obvious, Minimal Language)](https://toml.io/) parser and serializer for Free Pascal with broad TOML v1.0.0 support, including nested tables, arrays of tables, quoted dotted keys, Unicode escapes, strict basic-string escape handling, and local date/time values.
 
 > [!NOTE] 
 > 
-> Our extensive test suite (68 tests) covers the TOML v1.0.0 behavior implemented by TOML-FP across core data types, structures, serialization, and error cases.
+> Our extensive test suite (70 tests) covers the TOML v1.0.0 behavior implemented by TOML-FP across core data types, structures, serialization, and error cases.
 
 ## Table of Contents
 
@@ -63,7 +63,7 @@ TOML-FP provides a complete solution for working with TOML configuration files i
 - **Error Handling:** Detailed error messages and exception handling
 - **Serialization:** Convert Pascal objects to TOML and back
 - **Documentation:** Comprehensive examples and API documentation
-- **Test Suite:** Comprehensive test suite (68 items)
+- **Test Suite:** Comprehensive test suite (70 items)
 
 ## To Do / In Progress
 
@@ -497,7 +497,7 @@ Serializes a `TTOMLValue` and saves it to the specified file. Returns `True` on 
 
 ## Testing
 
-The library includes a comprehensive test suite (68 items). 
+The library includes a comprehensive test suite (70 items). 
 
 To run the tests:
 
@@ -523,14 +523,14 @@ See [Test-Coverage-Overview.md](docs/Test-Coverage-Overview.md) for details.
 
 ```bash
 $ ./TestRunner.exe -a --format=plain
- Time:00.032 N:68 E:0 F:0 I:0
-  TTOMLTestCase Time:00.032 N:68 E:0 F:0 I:0
+ Time:00.032 N:70 E:0 F:0 I:0
+  TTOMLTestCase Time:00.032 N:70 E:0 F:0 I:0
     Test01_StringValue
     Test02_IntegerValue
     ...
     Test72_LiteralDottedKeyTable
 
-Number of run tests: 68
+Number of run tests: 70
 Number of errors:    0
 Number of failures:  0
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![Free Pascal](https://img.shields.io/badge/Free%20Pascal-3.2.2-blue.svg)](https://www.freepascal.org/)
 [![Lazarus](https://img.shields.io/badge/Lazarus-4.0-orange.svg)](https://www.lazarus-ide.org/)
 [![TOML](https://img.shields.io/badge/TOML-1.0.0-green.svg)](https://toml.io/)
-[![Version](https://img.shields.io/badge/Version-1.0.3-blueviolet.svg)]()
+[![Version](https://img.shields.io/badge/Version-1.0.4-blueviolet.svg)]()
 
-A robust [TOML (Tom's Obvious, Minimal Language)](https://toml.io/) parser and serializer for Free Pascal, _almost_ fully compliant with the TOML v1.0.0 specification.
+A robust [TOML (Tom's Obvious, Minimal Language)](https://toml.io/) parser and serializer for Free Pascal with broad TOML v1.0.0 support, including nested tables, arrays of tables, quoted dotted keys, Unicode escapes, and local date/time values.
 
 > [!NOTE] 
 > 
-> Our extensive test suite (60 tests) ensures that TOML-FP adheres to the TOML v1.0.0 specification, covering all essential data types, structures, and edge cases.
+> Our extensive test suite (68 tests) covers the TOML v1.0.0 behavior implemented by TOML-FP across core data types, structures, serialization, and error cases.
 
 ## Table of Contents
 
@@ -63,7 +63,7 @@ TOML-FP provides a complete solution for working with TOML configuration files i
 - **Error Handling:** Detailed error messages and exception handling
 - **Serialization:** Convert Pascal objects to TOML and back
 - **Documentation:** Comprehensive examples and API documentation
-- **Test Suite:** Comprehensive test suite (60 items)
+- **Test Suite:** Comprehensive test suite (68 items)
 
 ## To Do / In Progress
 
@@ -497,7 +497,7 @@ Serializes a `TTOMLValue` and saves it to the specified file. Returns `True` on 
 
 ## Testing
 
-The library includes a comprehensive test suite (60 items). 
+The library includes a comprehensive test suite (68 items). 
 
 To run the tests:
 
@@ -523,20 +523,20 @@ See [Test-Coverage-Overview.md](docs/Test-Coverage-Overview.md) for details.
 
 ```bash
 $ ./TestRunner.exe -a --format=plain
- Time:00.049 N:60 E:0 F:0 I:0
-  TTOMLTestCase Time:00.049 N:60 E:0 F:0 I:0
+ Time:00.032 N:68 E:0 F:0 I:0
+  TTOMLTestCase Time:00.032 N:68 E:0 F:0 I:0
     Test01_StringValue
     Test02_IntegerValue
     ...
     Test72_LiteralDottedKeyTable
 
-Number of run tests: 60
+Number of run tests: 68
 Number of errors:    0
 Number of failures:  0
 
 Heap dump by heaptrc unit of path\to\TestRunner.exe
-3871 memory blocks allocated : 248475/265224
-3871 memory blocks freed     : 248475/265224
+4417 memory blocks allocated : 289154/309056
+4417 memory blocks freed     : 289154/309056
 0 unfreed memory blocks : 0
 True heap size : 294912 (256 used in System startup)
 True free heap : 294656

--- a/docs/Test-Coverage-Overview.md
+++ b/docs/Test-Coverage-Overview.md
@@ -1,6 +1,6 @@
 # Test Coverage Overview
 
-Your test suite comprises 59 tests, categorized as follows:
+Your test suite comprises 70 tests, categorized as follows:
 
 ## Basic Types Tests (Procedures 1-6):
 - String, Integer, Float, Boolean, DateTime values.
@@ -31,10 +31,10 @@ Your test suite comprises 59 tests, categorized as follows:
 - Invalid Table Keys: Validating table key formats.
 
 ## TOML v1.0.0 Specification Tests (Procedures 50-60):
-- Multiline Strings, Literal Strings: Handling different string formats.
+- Multiline Strings, Literal Strings: Handling different string formats, including Unicode escapes, strict basic-string escape validation, and multiline trimming rules.
 - Numerical Formats: Integers with underscores, hexadecimal, octal, binary.
 - Floating Points with Underscores: Ensuring proper parsing.
-- DateTime Variants: Local dates, times, and datetime with offsets.
+- DateTime Variants: Local dates, times, local datetimes with `T` or space separators, and datetime with offsets.
 - Array of Tables, Dotted Table Keys: Advanced table structures.
 
 ## Additional Specification Tests (Procedures 61-72):

--- a/packages/lazarus/toml_fp.lpk
+++ b/packages/lazarus/toml_fp.lpk
@@ -15,7 +15,7 @@
         <CustomOptions Value="-FcUTF8"/>
       </Other>
     </CompilerOptions>
-    <Description Value="A robust TOML (Tom&apos;s Obvious, Minimal Language) parser and serializer for Free Pascal, almost fully compliant with the TOML v1.0.0 specification."/>
+    <Description Value="A robust TOML (Tom&apos;s Obvious, Minimal Language) parser and serializer for Free Pascal with broad TOML v1.0.0 support."/>
     <License Value="MIT License
 
 Copyright (c) 2025 ikelaiah
@@ -37,7 +37,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."/>
-    <Version Major="1" Release="3"/>
+    <Version Major="1" Release="4"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\TOML.Parser.pas"/>

--- a/src/TOML.Parser.pas
+++ b/src/TOML.Parser.pas
@@ -506,7 +506,6 @@ begin
           'r': TempValue := TempValue + #13;
           '\': TempValue := TempValue + '\';
           '"': TempValue := TempValue + '"';
-          '''': TempValue := TempValue + '''';
           'u': begin
             Advance;
             TempValue := TempValue + ConsumeUnicodeEscape(4);
@@ -1216,9 +1215,10 @@ begin
     end;
     
     // Try to parse time part (HH:MM:SS[.fraction])
-    if (P <= Length(DateStr)) and ((DateStr[P] = 'T') or not HasDate) then
+    if (P <= Length(DateStr)) and (((DateStr[P] = 'T') or (DateStr[P] = ' ')) or not HasDate) then
     begin
-      if DateStr[P] = 'T' then Inc(P);
+      if HasDate and ((DateStr[P] = 'T') or (DateStr[P] = ' ')) then
+        Inc(P);
       
       if (P + 7 <= Length(DateStr)) and (DateStr[P+2] = ':') and (DateStr[P+5] = ':') then
       begin

--- a/src/TOML.Parser.pas
+++ b/src/TOML.Parser.pas
@@ -264,6 +264,11 @@ begin
   end;
 end;
 
+function IsValueTerminator(C: Char): Boolean;
+begin
+  Result := C in [#0, ' ', #9, #10, #13, '#', ',', ']', '}'];
+end;
+
 { TTOMLLexer }
 
 constructor TTOMLLexer.Create(const AInput: string);
@@ -351,6 +356,98 @@ var
   QuoteChar: Char;
   StartColumn: Integer;
   TempValue: string;
+  function HexDigitValue(C: Char): Integer;
+  begin
+    case C of
+      '0'..'9': Result := Ord(C) - Ord('0');
+      'A'..'F': Result := Ord(C) - Ord('A') + 10;
+      'a'..'f': Result := Ord(C) - Ord('a') + 10;
+      else Result := -1;
+    end;
+  end;
+
+  function CodePointToUTF8(CodePoint: Cardinal): string;
+  begin
+    if CodePoint <= $7F then
+      Result := Chr(CodePoint)
+    else if CodePoint <= $7FF then
+      Result := Chr($C0 or (CodePoint shr 6)) +
+        Chr($80 or (CodePoint and $3F))
+    else if CodePoint <= $FFFF then
+      Result := Chr($E0 or (CodePoint shr 12)) +
+        Chr($80 or ((CodePoint shr 6) and $3F)) +
+        Chr($80 or (CodePoint and $3F))
+    else
+      Result := Chr($F0 or (CodePoint shr 18)) +
+        Chr($80 or ((CodePoint shr 12) and $3F)) +
+        Chr($80 or ((CodePoint shr 6) and $3F)) +
+        Chr($80 or (CodePoint and $3F));
+  end;
+
+  function ConsumeUnicodeEscape(DigitCount: Integer): string;
+  var
+    CodePoint: Cardinal;
+    DigitValue: Integer;
+    i: Integer;
+  begin
+    CodePoint := 0;
+    for i := 1 to DigitCount do
+    begin
+      if IsAtEnd then
+        raise ETOMLParserException.Create('Unexpected end of input in Unicode escape');
+
+      DigitValue := HexDigitValue(Peek);
+      if DigitValue < 0 then
+        raise ETOMLParserException.Create('Invalid Unicode escape sequence');
+
+      CodePoint := (CodePoint shl 4) or Cardinal(DigitValue);
+      Advance;
+    end;
+
+    if (CodePoint > $10FFFF) or ((CodePoint >= $D800) and (CodePoint <= $DFFF)) then
+      raise ETOMLParserException.Create('Invalid Unicode code point');
+
+    Result := CodePointToUTF8(CodePoint);
+  end;
+
+  function ConsumeMultilineTrimmedWhitespace: Boolean;
+  var
+    SavePos: Integer;
+    SaveLine: Integer;
+    SaveColumn: Integer;
+    HasNewLine: Boolean;
+  begin
+    SavePos := FPosition;
+    SaveLine := FLine;
+    SaveColumn := FColumn;
+    HasNewLine := False;
+
+    while not IsAtEnd and (Peek in [' ', #9, #10, #13]) do
+    begin
+      if Peek = #13 then
+      begin
+        HasNewLine := True;
+        Advance;
+        if Peek = #10 then
+          Advance;
+      end
+      else
+      begin
+        if Peek = #10 then
+          HasNewLine := True;
+        Advance;
+      end;
+    end;
+
+    if not HasNewLine then
+    begin
+      FPosition := SavePos;
+      FLine := SaveLine;
+      FColumn := SaveColumn;
+    end;
+
+    Result := HasNewLine;
+  end;
 begin
   IsMultiline := False;
   IsLiteral := False;
@@ -365,13 +462,12 @@ begin
     IsMultiline := True;
     Advance; // Skip second quote
     Advance; // Skip third quote
-    if not IsLiteral then
-      // Skip first newline in multiline basic strings
-      if (Peek = #10) or ((Peek = #13) and (PeekNext = #10)) then
-      begin
-        if Peek = #13 then Advance;
-        if Peek = #10 then Advance;
-      end;
+    // Skip the first newline in multiline strings.
+    if (Peek = #10) or ((Peek = #13) and (PeekNext = #10)) then
+    begin
+      if Peek = #13 then Advance;
+      if Peek = #10 then Advance;
+    end;
   end;
   
   TempValue := '';
@@ -398,17 +494,28 @@ begin
       if (not IsLiteral) and (Peek = '\') then
       begin
         Advance; // Skip backslash
+
+        if IsMultiline and ConsumeMultilineTrimmedWhitespace then
+          Continue;
+
         case Peek of
+          'b': TempValue := TempValue + #8;
           'n': TempValue := TempValue + #10;
           't': TempValue := TempValue + #9;
+          'f': TempValue := TempValue + #12;
           'r': TempValue := TempValue + #13;
           '\': TempValue := TempValue + '\';
           '"': TempValue := TempValue + '"';
           '''': TempValue := TempValue + '''';
-          'u', 'U': begin
-            // Handle Unicode escapes
-            // TODO: Implement Unicode escape sequences
-            raise ETOMLParserException.Create('Unicode escapes not yet implemented');
+          'u': begin
+            Advance;
+            TempValue := TempValue + ConsumeUnicodeEscape(4);
+            Continue;
+          end;
+          'U': begin
+            Advance;
+            TempValue := TempValue + ConsumeUnicodeEscape(8);
+            Continue;
           end;
           else raise ETOMLParserException.Create('Invalid escape sequence');
         end;
@@ -440,22 +547,54 @@ var
   StartColumn: Integer;
   TempValue: string;
   Ch: Char;
-  
+  RawDigits: string;
+
   function IsHexDigit(C: Char): Boolean;
   begin
     Result := IsDigit(C) or (C in ['A'..'F', 'a'..'f']);
   end;
-  
+
   function IsBinDigit(C: Char): Boolean;
   begin
     Result := C in ['0', '1'];
   end;
-  
+
   function IsOctDigit(C: Char): Boolean;
   begin
     Result := C in ['0'..'7'];
   end;
-  
+
+  function ScanDigitSequence(const ValidDigits: TSysCharSet): string;
+  begin
+    Result := '';
+    while not IsAtEnd and ((Peek in ValidDigits) or (Peek = '_')) do
+      Result := Result + Advance;
+  end;
+
+  procedure ValidateUnderscores(const Digits, Context: string);
+  var
+    i: Integer;
+  begin
+    if Digits = '' then
+      raise ETOMLParserException.CreateFmt('Invalid %s: missing digits', [Context]);
+
+    if (Digits[1] = '_') or (Digits[Length(Digits)] = '_') then
+      raise ETOMLParserException.CreateFmt('Invalid %s: misplaced underscore', [Context]);
+
+    for i := 2 to Length(Digits) do
+      if (Digits[i] = '_') and (Digits[i - 1] = '_') then
+        raise ETOMLParserException.CreateFmt('Invalid %s: consecutive underscores', [Context]);
+  end;
+
+  function RemoveUnderscores(const S: string): string;
+  var
+    i: Integer;
+  begin
+    Result := '';
+    for i := 1 to Length(S) do
+      if S[i] <> '_' then
+        Result := Result + S[i];
+  end;
 begin
   IsFloat := False;
   StartColumn := FColumn;
@@ -511,21 +650,19 @@ begin
     begin
       TempValue := TempValue + Advance; // '0'
       TempValue := TempValue + Advance; // 'x', 'o', or 'b'
-      
+
       case Ch of
-        'X': while not IsAtEnd and (IsHexDigit(Peek) or (Peek = '_')) do
-               if Peek <> '_' then TempValue := TempValue + Advance
-               else Advance;
-               
-        'O': while not IsAtEnd and (IsOctDigit(Peek) or (Peek = '_')) do
-               if Peek <> '_' then TempValue := TempValue + Advance
-               else Advance;
-               
-        'B': while not IsAtEnd and (IsBinDigit(Peek) or (Peek = '_')) do
-               if Peek <> '_' then TempValue := TempValue + Advance
-               else Advance;
+        'X': RawDigits := ScanDigitSequence(['0'..'9', 'A'..'F', 'a'..'f']);
+        'O': RawDigits := ScanDigitSequence(['0'..'7']);
+        'B': RawDigits := ScanDigitSequence(['0', '1']);
       end;
-      
+
+      ValidateUnderscores(RawDigits, 'number');
+      TempValue := TempValue + RawDigits;
+
+      if (Ch = 'X') and (Peek in ['.', 'P', 'p']) then
+        raise ETOMLParserException.Create('Hexadecimal floating-point values are not supported by TOML');
+
       Result.TokenType := ttInteger;
       Result.Value := TempValue;
       Result.Line := FLine;
@@ -533,49 +670,46 @@ begin
       Exit;
     end;
   end;
-  
+
   // Scan integer part
-  while not IsAtEnd and (IsDigit(Peek) or (Peek = '_')) do
-    if Peek <> '_' then
-      TempValue := TempValue + Advance
-    else
-      Advance;
-  
+  RawDigits := ScanDigitSequence(['0'..'9']);
+  ValidateUnderscores(RawDigits, 'number');
+  TempValue := TempValue + RawDigits;
+
+  if (Length(RemoveUnderscores(RawDigits)) > 1) and (RemoveUnderscores(RawDigits)[1] = '0') then
+    raise ETOMLParserException.Create('Leading zeros are not allowed in decimal integers');
+
   // Check for decimal point
   if (Peek = '.') and IsDigit(PeekNext) then
   begin
     IsFloat := True;
     TempValue := TempValue + Advance; // Add decimal point
-    
+
     // Scan decimal part
-    while not IsAtEnd and (IsDigit(Peek) or (Peek = '_')) do
-      if Peek <> '_' then
-        TempValue := TempValue + Advance
-      else
-        Advance;
+    RawDigits := ScanDigitSequence(['0'..'9']);
+    ValidateUnderscores(RawDigits, 'float');
+    TempValue := TempValue + RawDigits;
   end;
-  
+
   // Check for exponent
   if Peek in ['e', 'E'] then
   begin
     IsFloat := True;
     TempValue := TempValue + Advance;
-    
+
     if Peek in ['+', '-'] then
       TempValue := TempValue + Advance;
-      
-    while not IsAtEnd and (IsDigit(Peek) or (Peek = '_')) do
-      if Peek <> '_' then
-        TempValue := TempValue + Advance
-      else
-        Advance;
+
+    RawDigits := ScanDigitSequence(['0'..'9']);
+    ValidateUnderscores(RawDigits, 'exponent');
+    TempValue := TempValue + RawDigits;
   end;
-  
+
   if IsFloat then
     Result.TokenType := ttFloat
   else
     Result.TokenType := ttInteger;
-    
+
   Result.Value := TempValue;
   Result.Line := FLine;
   Result.Column := StartColumn;
@@ -599,134 +733,142 @@ end;
 function TTOMLLexer.ScanDateTime: TToken;
 var
   StartColumn: Integer;
-  i: Integer;
   HasTime: Boolean;
-  HasTimezone: Boolean;
   HasDate: Boolean;
   TempValue: string;
-  
-  function ScanDigits(Count: Integer): Boolean;
+  TempPos: Integer;
+
+  function TempChar(Offset: Integer = 0): Char;
+  begin
+    if TempPos + Offset > Length(FInput) then
+      Result := #0
+    else
+      Result := FInput[TempPos + Offset];
+  end;
+
+  function ConsumeDigits(Count: Integer): Boolean;
   var
     i: Integer;
   begin
     Result := True;
     for i := 1 to Count do
     begin
-      if not IsDigit(Peek) then
-      begin
-        Result := False;
-        Exit;
-      end;
-      TempValue := TempValue + Advance;
+      if not (TempChar in ['0'..'9']) then
+        Exit(False);
+      TempValue := TempValue + TempChar;
+      Inc(TempPos);
     end;
   end;
-  
+
+  function ConsumeChar(Expected: Char): Boolean;
+  begin
+    Result := TempChar = Expected;
+    if Result then
+    begin
+      TempValue := TempValue + Expected;
+      Inc(TempPos);
+    end;
+  end;
+
+  function ParseTimePart: Boolean;
+  begin
+    Result := ConsumeDigits(2) and ConsumeChar(':') and
+      ConsumeDigits(2) and ConsumeChar(':') and ConsumeDigits(2);
+    if not Result then
+      Exit;
+
+    if TempChar = '.' then
+    begin
+      TempValue := TempValue + '.';
+      Inc(TempPos);
+      if not (TempChar in ['0'..'9']) then
+        Exit(False);
+      while TempChar in ['0'..'9'] do
+      begin
+        TempValue := TempValue + TempChar;
+        Inc(TempPos);
+      end;
+    end;
+  end;
+
+  function ParseTimezonePart: Boolean;
+  var
+    SavePos: Integer;
+    SaveLen: Integer;
+  begin
+    SavePos := TempPos;
+    SaveLen := Length(TempValue);
+    Result := False;
+    if TempChar = 'Z' then
+    begin
+      TempValue := TempValue + 'Z';
+      Inc(TempPos);
+      Exit(True);
+    end;
+
+    if not (TempChar in ['+', '-']) then
+      Exit(False);
+
+    TempValue := TempValue + TempChar;
+    Inc(TempPos);
+    Result := ConsumeDigits(2) and ConsumeChar(':') and ConsumeDigits(2);
+    if not Result then
+    begin
+      TempPos := SavePos;
+      SetLength(TempValue, SaveLen);
+    end;
+  end;
 begin
   StartColumn := FColumn;
   TempValue := '';
   HasDate := False;
   HasTime := False;
-  HasTimezone := False;
-  
-  // Try to parse as date (YYYY-MM-DD)
-  if ScanDigits(4) and (Peek = '-') then
+
+  TempPos := FPosition;
+
+  if ConsumeDigits(4) and ConsumeChar('-') and ConsumeDigits(2) and
+     ConsumeChar('-') and ConsumeDigits(2) then
   begin
-    TempValue := TempValue + Advance; // -
-    if ScanDigits(2) and (Peek = '-') then
+    HasDate := True;
+
+    if TempChar in ['T', 't', ' '] then
     begin
-      TempValue := TempValue + Advance; // -
-      if ScanDigits(2) then
-        HasDate := True;
-    end;
-  end;
-  
-  // Try to parse time (HH:MM:SS[.fraction])
-  if HasDate and (Peek = 'T') then
-  begin
-    TempValue := TempValue + Advance; // T
-    if ScanDigits(2) and (Peek = ':') then
-    begin
-      TempValue := TempValue + Advance; // :
-      if ScanDigits(2) and (Peek = ':') then
+      TempValue := TempValue + TempChar;
+      Inc(TempPos);
+      HasTime := ParseTimePart;
+      if not HasTime then
       begin
-        TempValue := TempValue + Advance; // :
-        if ScanDigits(2) then
-        begin
-          HasTime := True;
-          
-          // Optional fractional seconds
-          if Peek = '.' then
-          begin
-            TempValue := TempValue + Advance; // .
-            while IsDigit(Peek) do
-              TempValue := TempValue + Advance;
-          end;
-        end;
+        HasDate := False;
+        TempValue := '';
+        TempPos := FPosition;
       end;
     end;
+
+    if HasTime and (TempChar in ['Z', '+', '-']) then
+      ParseTimezonePart;
   end
-  else if not HasDate then
+  else
   begin
-    // Try to parse as time only (HH:MM:SS[.fraction])
-    if ScanDigits(2) and (Peek = ':') then
-    begin
-      TempValue := TempValue + Advance; // :
-      if ScanDigits(2) and (Peek = ':') then
-      begin
-        TempValue := TempValue + Advance; // :
-        if ScanDigits(2) then
-        begin
-          HasTime := True;
-          
-          // Optional fractional seconds
-          if Peek = '.' then
-          begin
-            TempValue := TempValue + Advance; // .
-            while IsDigit(Peek) do
-              TempValue := TempValue + Advance;
-          end;
-        end;
-      end;
-    end;
+    TempValue := '';
+    TempPos := FPosition;
   end;
-  
-  // Try to parse timezone
-  if HasTime and (Peek in ['Z', '+', '-']) then
+
+  if not HasDate then
   begin
-    if Peek = 'Z' then
-    begin
-      TempValue := TempValue + Advance;
-      HasTimezone := True;
-    end
-    else
-    begin
-      TempValue := TempValue + Advance; // + or -
-      if ScanDigits(2) then
-      begin
-        if Peek = ':' then
-        begin
-          TempValue := TempValue + Advance; // :
-          if ScanDigits(2) then
-            HasTimezone := True;
-        end
-        else
-          HasTimezone := True;
-      end;
-    end;
+    TempValue := '';
+    TempPos := FPosition;
+    HasTime := ParseTimePart;
   end;
-  
-  // Determine token type based on what we found
-  if HasDate and HasTime and HasTimezone then
-    Result.TokenType := ttDateTime
-  else if HasDate and HasTime then
-    Result.TokenType := ttDateTime
-  else if HasDate then
-    Result.TokenType := ttDateTime
-  else if HasTime then
-    Result.TokenType := ttDateTime
+
+  if (HasDate or HasTime) and IsValueTerminator(TempChar) then
+  begin
+    while FPosition < TempPos do
+      Advance;
+    Result.TokenType := ttDateTime;
+  end
   else
     Result.TokenType := ttInteger;
-  
+
   Result.Value := TempValue;
   Result.Line := FLine;
   Result.Column := StartColumn;
@@ -1037,8 +1179,6 @@ var
   DateStr: string;
   Year, Month, Day, Hour, Minute, Second: Word;
   MilliSecond: Word;
-  TZHour, TZMinute: Integer;
-  TZNegative: Boolean;
   P: Integer;
   FracStr: string;
   DT: TDateTime;
@@ -1160,7 +1300,6 @@ end;
 function TTOMLParser.ParseArray: TTOMLArray;
 var
   ItemValue: TTOMLValue;
-  HasNewline: Boolean;
 begin
   Result := TTOMLArray.Create;
   try
@@ -1170,22 +1309,15 @@ begin
     begin
       repeat
         // Skip any newlines between array elements
-        HasNewline := False;
         while FCurrentToken.TokenType = ttNewLine do
-        begin
-          HasNewline := True;
           Advance;
-        end;
 
         ItemValue := ParseValue;
         Result.Add(ItemValue);
         
         // Skip any newlines after array elements before comma
         while FCurrentToken.TokenType = ttNewLine do
-        begin
-          HasNewline := True;
           Advance;
-        end
       until not Match(ttComma);
       
       // Skip any newlines before closing bracket

--- a/src/TOML.Serializer.pas
+++ b/src/TOML.Serializer.pas
@@ -83,6 +83,7 @@ type
       @param AKey The key to check
       @returns True if key needs quoting, False otherwise }
     function NeedsQuoting(const AKey: string): Boolean;
+    function FormatKey(const AKey: string): string;
   public
     { Creates a new TOML serializer instance }
     constructor Create;
@@ -207,12 +208,39 @@ begin
   Result := False;
 end;
 
+function TTOMLSerializer.FormatKey(const AKey: string): string;
+var
+  i: Integer;
+  C: Char;
+begin
+  if not NeedsQuoting(AKey) then
+    Exit(AKey);
+
+  Result := '"';
+  for i := 1 to Length(AKey) do
+  begin
+    C := AKey[i];
+    case C of
+      #8:  Result := Result + '\b';
+      #9:  Result := Result + '\t';
+      #10: Result := Result + '\n';
+      #12: Result := Result + '\f';
+      #13: Result := Result + '\r';
+      '"': Result := Result + '\"';
+      '\': Result := Result + '\\';
+      else
+        if C < #32 then
+          Result := Result + Format('\u%.4x', [Ord(C)])
+        else
+          Result := Result + C;
+    end;
+  end;
+  Result := Result + '"';
+end;
+
 procedure TTOMLSerializer.WriteKey(const AKey: string);
 begin
-  if NeedsQuoting(AKey) then
-    WriteString(AKey)
-  else
-    FStringBuilder.Append(AKey);
+  FStringBuilder.Append(FormatKey(AKey));
 end;
 
 procedure TTOMLSerializer.WriteString(const AValue: string);
@@ -323,9 +351,25 @@ var
   i: Integer;
   ArrayValue: TTOMLArray;
   AllTables: Boolean;
-  TablePath: string; 
-  PathComponents: TStringList;
-  Component: string;
+  function BuildPath(const AKey: string): string;
+  var
+    i: Integer;
+  begin
+    Result := '';
+    for i := 0 to FCurrentPath.Count - 1 do
+    begin
+      if Result <> '' then
+        Result := Result + '.';
+      Result := Result + FormatKey(FCurrentPath[i]);
+    end;
+
+    if AKey <> '' then
+    begin
+      if Result <> '' then
+        Result := Result + '.';
+      Result := Result + FormatKey(AKey);
+    end;
+  end;
 begin
   if AInline then
   begin
@@ -389,10 +433,14 @@ begin
           begin
             if i > 0 then
               WriteLine;
-            WriteLine('[[' + Pair.Key + ']]');
-            
-            // Save current indentation level
-            WriteTable(ArrayValue.GetItem(i).AsTable);
+            WriteLine('[[' + BuildPath(Pair.Key) + ']]');
+
+            FCurrentPath.Add(Pair.Key);
+            try
+              WriteTable(ArrayValue.GetItem(i).AsTable);
+            finally
+              FCurrentPath.Delete(FCurrentPath.Count - 1);
+            end;
           end;
           continue;
         end;
@@ -404,46 +452,17 @@ begin
         SubTable := Pair.Value.AsTable;
         
         WriteLine;
-        
-        // Build path components properly
-        PathComponents := TStringList.Create;
-        try
-          // Add all current path components with proper quoting if needed
-          for i := 0 to FCurrentPath.Count - 1 do
-          begin
-            Component := FCurrentPath[i];
-            if NeedsQuoting(Component) then
-              PathComponents.Add('"' + Component + '"')
-            else
-              PathComponents.Add(Component);
-          end;
-          
-          // Add the current key with proper quoting if needed
-          if NeedsQuoting(Pair.Key) then
-            PathComponents.Add('"' + Pair.Key + '"')
-          else
-            PathComponents.Add(Pair.Key);
-          
-          // Join with dots to create the full path
-          TablePath := '';
-          for i := 0 to PathComponents.Count - 1 do
-          begin
-            if i > 0 then
-              TablePath := TablePath + '.';
-            TablePath := TablePath + PathComponents[i];
-          end;
-          
-          WriteLine('[' + TablePath + ']');
-          
-          // Process the subtable recursively if it has items
-          if SubTable.Items.Count > 0 then
-          begin
-            FCurrentPath.Add(Pair.Key);
+
+        WriteLine('[' + BuildPath(Pair.Key) + ']');
+
+        if SubTable.Items.Count > 0 then
+        begin
+          FCurrentPath.Add(Pair.Key);
+          try
             WriteTable(SubTable);
+          finally
             FCurrentPath.Delete(FCurrentPath.Count - 1);
           end;
-        finally
-          PathComponents.Free;
         end;
       end;
     end;

--- a/tests/TestCaseTOML.pas
+++ b/tests/TestCaseTOML.pas
@@ -46,6 +46,7 @@ type
     procedure Test36_1_SerializeHierarchicalNestedTable;
     procedure Test36_2_SerializeLiteralDottedKeyTable;
     procedure Test37_SerializeArrayOfTables;
+    procedure Test37_1_SerializeArrayOfTablesWithQuotedKey;
     
     { Error Cases }
     procedure Test40_InvalidInteger;
@@ -56,11 +57,17 @@ type
     
     { TOML v1.0.0 Specification Tests }
     procedure Test50_MultilineString;
+    procedure Test50_1_UnicodeEscapeSequences;
+    procedure Test50_2_BasicStringAdditionalEscapes;
+    procedure Test50_3_MultilineBasicBackslashTrim;
     procedure Test51_LiteralString;
     procedure Test52_MultilineLiteralString;
+    procedure Test52_1_MultilineLiteralStringSkipsInitialNewline;
     procedure Test53_IntegerWithUnderscores;
+    procedure Test53_1_InvalidNumericUnderscores;
     procedure Test54_HexOctBinIntegers;
     procedure Test55_FloatWithUnderscores;
+    procedure Test55_1_RejectHexFloat;
     procedure Test56_LocalDateTime;
     procedure Test57_LocalDate;
     procedure Test58_LocalTime;
@@ -74,6 +81,7 @@ type
     procedure Test62_OffsetDateTime;
     procedure Test63_MultilineArray;
     procedure Test64_QuotedKeys;
+    procedure Test64_1_DottedQuotedKeysInInlineTable;
     procedure Test65_SuperTables;
     procedure Test66_WhitespaceHandling;
     procedure Test67_ArrayTypeValidation;
@@ -640,6 +648,42 @@ begin
   end;
 end;
 
+procedure TTOMLTestCase.Test37_1_SerializeArrayOfTablesWithQuotedKey;
+var
+  Doc: TTOMLTable;
+  Items: TTOMLArray;
+  Entry: TTOMLTable;
+  TOML: string;
+  ParsedDoc: TTOMLTable;
+  Value: TTOMLValue;
+begin
+  Doc := TTOMLTable.Create;
+  try
+    Items := TTOMLArray.Create;
+    Entry := TTOMLTable.Create;
+    Entry.Add('name', TTOMLString.Create('apple'));
+    Items.Add(Entry);
+    Doc.Add('fruit.apple', Items);
+
+    TOML := SerializeTOML(Doc);
+    AssertTrue('Array-of-table header is quoted as one key',
+      Pos('[["fruit.apple"]]', TOML) > 0);
+
+    ParsedDoc := ParseTOML(TOML);
+    try
+      AssertTrue('Quoted array-of-table key exists', ParsedDoc.TryGetValue('fruit.apple', Value));
+      AssertEquals('Quoted array-of-table count matches', 1, Value.AsArray.Count);
+      AssertTrue('Round-tripped item exists',
+        Value.AsArray.Items[0].AsTable.TryGetValue('name', Value));
+      AssertEquals('Round-tripped item name matches', 'apple', Value.AsString);
+    finally
+      ParsedDoc.Free;
+    end;
+  finally
+    Doc.Free;
+  end;
+end;
+
 procedure TTOMLTestCase.Test40_InvalidInteger;
 begin
   try
@@ -714,6 +758,60 @@ begin
   end;
 end;
 
+procedure TTOMLTestCase.Test50_1_UnicodeEscapeSequences;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+  Expected: string;
+begin
+  TOML := 'escaped = "Snowman: \u2603, clef: \U0001D11E"' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Escaped value exists', Doc.TryGetValue('escaped', Value));
+    Expected := 'Snowman: ' + #$E2#$98#$83 + ', clef: ' + #$F0#$9D#$84#$9E;
+    AssertEquals('Unicode escapes are decoded', Expected, Value.AsString);
+  finally
+    Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test50_2_BasicStringAdditionalEscapes;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+begin
+  TOML := 'escaped = "a\b\f"' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Escaped value exists', Doc.TryGetValue('escaped', Value));
+    AssertEquals('Basic string supports \\b and \\f', 'a' + #8 + #12, Value.AsString);
+  finally
+    Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test50_3_MultilineBasicBackslashTrim;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+begin
+  TOML := 'str = """' + LineEnding +
+          'The quick \' + LineEnding +
+          '  brown \' + LineEnding +
+          '  fox"""' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Multiline string exists', Doc.TryGetValue('str', Value));
+    AssertEquals('Line-ending backslashes trim newlines and indentation',
+      'The quick brown fox', Value.AsString);
+  finally
+    Doc.Free;
+  end;
+end;
+
 procedure TTOMLTestCase.Test51_LiteralString;
 var
   TOML: string;
@@ -749,6 +847,25 @@ begin
   end;
 end;
 
+procedure TTOMLTestCase.Test52_1_MultilineLiteralStringSkipsInitialNewline;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+begin
+  TOML := 'literal = ''''''' + LineEnding +
+          'alpha' + LineEnding +
+          'beta''''''' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Literal value exists', Doc.TryGetValue('literal', Value));
+    AssertEquals('Initial newline is trimmed from multiline literal strings',
+      'alpha' + LineEnding + 'beta', Value.AsString);
+  finally
+    Doc.Free;
+  end;
+end;
+
 procedure TTOMLTestCase.Test53_IntegerWithUnderscores;
 var
   TOML: string;
@@ -768,6 +885,41 @@ begin
     AssertEquals(12345, Value.AsInteger);
   finally
     Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test53_1_InvalidNumericUnderscores;
+begin
+  try
+    ParseTOML('bad = 1__000');
+    Fail('Double underscores should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
+  end;
+
+  try
+    ParseTOML('bad = 1000_');
+    Fail('Trailing underscores should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
+  end;
+
+  try
+    ParseTOML('bad = 1_.5');
+    Fail('Underscores adjacent to decimal points should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
+  end;
+
+  try
+    ParseTOML('bad = 1e_10');
+    Fail('Underscores adjacent to exponents should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
   end;
 end;
 
@@ -809,6 +961,17 @@ begin
     AssertEquals(1e10, Value.AsFloat, 0.0);
   finally
     Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test55_1_RejectHexFloat;
+begin
+  try
+    ParseTOML('bad = 0x1.fp3');
+    Fail('Hexadecimal floating-point syntax should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
   end;
 end;
 
@@ -855,11 +1018,11 @@ var
   Doc: TTOMLTable;
   Value: TTOMLValue;
 begin
-  TOML := 'time = "07:32:00"';
+  TOML := 'time = 07:32:00';
   Doc := ParseTOML(TOML);
   try
     AssertTrue('Time exists', Doc.TryGetValue('time', Value));
-    AssertEquals('07:32:00', Value.AsString);
+    AssertEquals('07:32:00', FormatDateTime('hh:nn:ss', Value.AsDateTime));
   finally
     Doc.Free;
   end;
@@ -1065,6 +1228,29 @@ begin
     
     AssertTrue('Unicode key exists', Doc.TryGetValue('ʎǝʞ', Value));
     AssertEquals('key', Value.AsString);
+  finally
+    Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test64_1_DottedQuotedKeysInInlineTable;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+  InlineTable: TTOMLTable;
+begin
+  TOML := 'site = { "google.com" = true, web."example.org" = false }' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Inline table exists', Doc.TryGetValue('site', Value));
+    InlineTable := Value.AsTable;
+
+    AssertTrue('Quoted inline key exists', InlineTable.TryGetValue('google.com', Value));
+    AssertTrue('Quoted inline key value matches', Value.AsBoolean);
+
+    AssertTrue('Dotted quoted inline key exists', InlineTable.TryGetValue('web.example.org', Value));
+    AssertFalse('Dotted quoted inline key value matches', Value.AsBoolean);
   finally
     Doc.Free;
   end;

--- a/tests/TestCaseTOML.pas
+++ b/tests/TestCaseTOML.pas
@@ -60,6 +60,7 @@ type
     procedure Test50_1_UnicodeEscapeSequences;
     procedure Test50_2_BasicStringAdditionalEscapes;
     procedure Test50_3_MultilineBasicBackslashTrim;
+    procedure Test50_4_RejectInvalidBasicStringEscape;
     procedure Test51_LiteralString;
     procedure Test52_MultilineLiteralString;
     procedure Test52_1_MultilineLiteralStringSkipsInitialNewline;
@@ -69,6 +70,7 @@ type
     procedure Test55_FloatWithUnderscores;
     procedure Test55_1_RejectHexFloat;
     procedure Test56_LocalDateTime;
+    procedure Test56_1_SpaceSeparatedLocalDateTime;
     procedure Test57_LocalDate;
     procedure Test58_LocalTime;
     procedure Test59_ArrayOfTables;
@@ -812,6 +814,17 @@ begin
   end;
 end;
 
+procedure TTOMLTestCase.Test50_4_RejectInvalidBasicStringEscape;
+begin
+  try
+    ParseTOML('escaped = "a\''b"');
+    Fail('Invalid basic string escape should be rejected');
+  except
+    on E: ETOMLParserException do
+      ;
+  end;
+end;
+
 procedure TTOMLTestCase.Test51_LiteralString;
 var
   TOML: string;
@@ -991,6 +1004,23 @@ begin
     AssertTrue('Second datetime exists', Doc.TryGetValue('ldt2', Value));
     AssertEquals('1979-05-27T00:32:00.999', 
       FormatDateTime('yyyy-mm-dd"T"hh:nn:ss.zzz', Value.AsDateTime));
+  finally
+    Doc.Free;
+  end;
+end;
+
+procedure TTOMLTestCase.Test56_1_SpaceSeparatedLocalDateTime;
+var
+  TOML: string;
+  Doc: TTOMLTable;
+  Value: TTOMLValue;
+begin
+  TOML := 'ldt = 1979-05-27 07:32:00' + LineEnding;
+  Doc := ParseTOML(TOML);
+  try
+    AssertTrue('Space-separated datetime exists', Doc.TryGetValue('ldt', Value));
+    AssertEquals('1979-05-27T07:32:00',
+      FormatDateTime('yyyy-mm-dd"T"hh:nn:ss', Value.AsDateTime));
   finally
     Doc.Free;
   end;

--- a/tests/TestRunner.lps
+++ b/tests/TestRunner.lps
@@ -11,7 +11,7 @@
         <EditorIndex Value="2"/>
         <TopLine Value="6"/>
         <CursorPos X="4" Y="17"/>
-        <UsageCount Value="59"/>
+        <UsageCount Value="101"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -19,21 +19,21 @@
         <IsPartOfProject Value="True"/>
         <TopLine Value="1295"/>
         <CursorPos X="6" Y="1303"/>
-        <UsageCount Value="59"/>
+        <UsageCount Value="101"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
         <Filename Value="C:\lazarus\fpc\3.2.2\source\packages\fcl-fpcunit\src\testregistry.pp"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="7"/>
+        <UsageCount Value="3"/>
       </Unit>
       <Unit>
         <Filename Value="..\src\TOML.Parser.pas"/>
         <IsVisibleTab Value="True"/>
         <EditorIndex Value="1"/>
         <TopLine Value="1175"/>
-        <CursorPos X="79" Y="1188"/>
-        <UsageCount Value="29"/>
+        <CursorPos X="19" Y="1182"/>
+        <UsageCount Value="50"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -41,7 +41,7 @@
         <EditorIndex Value="4"/>
         <TopLine Value="222"/>
         <CursorPos X="14" Y="223"/>
-        <UsageCount Value="29"/>
+        <UsageCount Value="50"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -49,7 +49,7 @@
         <EditorIndex Value="3"/>
         <TopLine Value="280"/>
         <CursorPos X="5" Y="287"/>
-        <UsageCount Value="21"/>
+        <UsageCount Value="42"/>
         <Loaded Value="True"/>
       </Unit>
     </Units>

--- a/tests/TestRunner.lps
+++ b/tests/TestRunner.lps
@@ -11,7 +11,7 @@
         <EditorIndex Value="2"/>
         <TopLine Value="6"/>
         <CursorPos X="4" Y="17"/>
-        <UsageCount Value="57"/>
+        <UsageCount Value="59"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -19,7 +19,7 @@
         <IsPartOfProject Value="True"/>
         <TopLine Value="1295"/>
         <CursorPos X="6" Y="1303"/>
-        <UsageCount Value="57"/>
+        <UsageCount Value="59"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -29,23 +29,19 @@
       </Unit>
       <Unit>
         <Filename Value="..\src\TOML.Parser.pas"/>
+        <IsVisibleTab Value="True"/>
         <EditorIndex Value="1"/>
-        <TopLine Value="1211"/>
-        <CursorPos X="5" Y="1217"/>
-        <UsageCount Value="28"/>
+        <TopLine Value="1175"/>
+        <CursorPos X="79" Y="1188"/>
+        <UsageCount Value="29"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
         <Filename Value="..\src\TOML.Serializer.pas"/>
-        <IsVisibleTab Value="True"/>
         <EditorIndex Value="4"/>
-        <TopLine Value="221"/>
-<<<<<<< HEAD
-        <CursorPos X="51" Y="232"/>
-=======
-        <CursorPos X="14" Y="227"/>
->>>>>>> d2adbd610a19bf24c388025c71ac602130546539
-        <UsageCount Value="28"/>
+        <TopLine Value="222"/>
+        <CursorPos X="14" Y="223"/>
+        <UsageCount Value="29"/>
         <Loaded Value="True"/>
       </Unit>
       <Unit>
@@ -53,15 +49,11 @@
         <EditorIndex Value="3"/>
         <TopLine Value="280"/>
         <CursorPos X="5" Y="287"/>
-        <UsageCount Value="20"/>
+        <UsageCount Value="21"/>
         <Loaded Value="True"/>
       </Unit>
     </Units>
     <JumpHistory HistoryIndex="29">
-      <Position>
-        <Filename Value="..\src\TOML.Serializer.pas"/>
-        <Caret Line="8" Column="54"/>
-      </Position>
       <Position>
         <Filename Value="..\src\TOML.Serializer.pas"/>
         <Caret Line="224" Column="18" TopLine="219"/>
@@ -177,6 +169,10 @@
       <Position>
         <Filename Value="TestCaseTOML.pas"/>
         <Caret Line="276" Column="56" TopLine="275"/>
+      </Position>
+      <Position>
+        <Filename Value="..\src\TOML.Serializer.pas"/>
+        <Caret Line="223" Column="14" TopLine="222"/>
       </Position>
     </JumpHistory>
     <RunParams>


### PR DESCRIPTION
## Pull Request Description

This PR improves TOML 1.0 compliance in the parser and serializer, adds regression coverage for the affected edge cases, fixes a broken Lazarus session file, and updates the documentation to reflect the current project state.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior?

Several TOML 1.0 edge cases were either unsupported or handled incorrectly in the current parser/serializer implementation. These included:
- missing Unicode escape decoding in basic strings
- missing `\b` and `\f` basic-string escapes
- incorrect multiline string trimming behavior
- local-time parsing gaps
- serializer output for quoted dotted keys
- invalid numeric formats being accepted too loosely

During review, two additional parser defects were also confirmed:
- space-separated local datetimes (for example `1979-05-27 07:32:00`) lost the time component
- invalid basic-string escape `\'` was accepted instead of rejected

There was also a broken Lazarus session file caused by unresolved merge markers.

Issue Number: #9 

### What is the new behavior?

This PR:
- implements `\uXXXX` and `\UXXXXXXXX` decoding for basic strings
- adds support for `\b` and `\f`
- fixes multiline string handling:
  - trims the first newline in multiline literal strings
  - honors line-ending backslash whitespace trimming in multiline basic strings
- fixes bare local-time parsing such as `07:32:00`
- fixes space-separated local datetime parsing such as `1979-05-27 07:32:00`
- tightens numeric validation:
  - rejects invalid underscore placement
  - rejects decimal leading zeros
  - rejects hexadecimal floating-point syntax
- rejects invalid TOML basic-string escapes such as `\'`
- fixes serializer handling of quoted dotted keys in table headers and arrays of tables
- adds regression tests for the above cases
- updates `README.md`, `CHANGELOG.md`, and `docs/Test-Coverage-Overview.md`

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Additional context

Validation performed locally:

```text
TestRunner.exe -a --format=plain
Number of run tests: 70
Number of errors:    0
Number of failures:  0
